### PR TITLE
Return contacts that start with query instead of contains

### DIFF
--- a/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
+++ b/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
@@ -187,7 +187,7 @@ public class ContactsServicePlugin implements MethodCallHandler {
             StructuredPostal.CONTENT_ITEM_TYPE,
     };
     if(query != null){
-      selectionArgs = new String[]{"%" + query + "%"};
+      selectionArgs = new String[]{query + "%"};
       selection = ContactsContract.Contacts.DISPLAY_NAME_PRIMARY + " LIKE ?";
     }
     return contentResolver.query(ContactsContract.Data.CONTENT_URI, PROJECTION, selection, selectionArgs, null);


### PR DESCRIPTION
This behavior is default on iOS.