### PR TITLE
Fix getContacts in iOS 13.

### DIFF
--- a/ios/Classes/SwiftContactsServicePlugin.swift
+++ b/ios/Classes/SwiftContactsServicePlugin.swift
@@ -66,7 +66,6 @@ public class SwiftContactsServicePlugin: NSObject, FlutterPlugin {
                     CNContactNameSuffixKey,
                     CNContactPostalAddressesKey,
                     CNContactOrganizationNameKey,
-                    CNContactNoteKey,
                     CNContactJobTitleKey] as [Any]
         
         if(withThumbnails){
@@ -179,7 +178,6 @@ public class SwiftContactsServicePlugin: NSObject, FlutterPlugin {
                     CNContactNameSuffixKey,
                     CNContactPostalAddressesKey,
                     CNContactOrganizationNameKey,
-                    CNContactNoteKey,
                     CNContactImageDataKey,
                     CNContactJobTitleKey] as [Any]
         do {
@@ -195,7 +193,6 @@ public class SwiftContactsServicePlugin: NSObject, FlutterPlugin {
                 contact.nameSuffix = dictionary["suffix"] as? String ?? ""
                 contact.organizationName = dictionary["company"] as? String ?? ""
                 contact.jobTitle = dictionary["jobTitle"] as? String ?? ""
-                contact.note = dictionary["note"] as? String ?? ""
                 contact.imageData = (dictionary["avatar"] as? FlutterStandardTypedData)?.data
 
                 //Phone numbers
@@ -257,7 +254,6 @@ public class SwiftContactsServicePlugin: NSObject, FlutterPlugin {
         contact.nameSuffix = dictionary["suffix"] as? String ?? ""
         contact.organizationName = dictionary["company"] as? String ?? ""
         contact.jobTitle = dictionary["jobTitle"] as? String ?? ""
-        contact.note = dictionary["note"] as? String ?? ""
         if let avatarData = (dictionary["avatar"] as? FlutterStandardTypedData)?.data {
             contact.imageData = avatarData
         }
@@ -308,7 +304,6 @@ public class SwiftContactsServicePlugin: NSObject, FlutterPlugin {
         result["suffix"] = contact.nameSuffix
         result["company"] = contact.organizationName
         result["jobTitle"] = contact.jobTitle
-        result["note"] = contact.note
         if contact.isKeyAvailable(CNContactThumbnailImageDataKey) {
             if let avatarData = contact.thumbnailImageData {
                 result["avatar"] = FlutterStandardTypedData(bytes: avatarData)

--- a/lib/contacts_service.dart
+++ b/lib/contacts_service.dart
@@ -63,10 +63,9 @@ class Contact {
     this.phones,
     this.postalAddresses,
     this.avatar,
-    this.note
   });
 
-  String identifier, displayName, givenName, middleName, prefix, suffix, familyName, company, jobTitle, note;
+  String identifier, displayName, givenName, middleName, prefix, suffix, familyName, company, jobTitle;
   Iterable<Item> emails = [];
   Iterable<Item> phones = [];
   Iterable<PostalAddress> postalAddresses = [];
@@ -96,7 +95,6 @@ class Contact {
     postalAddresses = (m["postalAddresses"] as Iterable)
         ?.map((m) => PostalAddress.fromMap(m));
     avatar = m["avatar"];
-    note = m["note"];
   }
 
   static Map _toMap(Contact contact) {
@@ -125,8 +123,7 @@ class Contact {
       "emails": emails,
       "phones": phones,
       "postalAddresses": postalAddresses,
-      "avatar": contact.avatar,
-      "note": contact.note
+      "avatar": contact.avatar
     };
   }
 
@@ -143,7 +140,6 @@ class Contact {
       familyName: this.familyName ?? other.familyName,
       company: this.company ?? other.company,
       jobTitle: this.jobTitle ?? other.jobTitle,
-      note: this.note ?? other.note,
       emails: this.emails == null
           ? other.emails
           : this.emails.toSet().union(other.emails?.toSet() ?? Set()).toList(),
@@ -171,7 +167,6 @@ class Contact {
         this.identifier == other.identifier &&
         this.jobTitle == other.jobTitle &&
         this.middleName == other.middleName &&
-        this.note == other.note &&
         this.prefix == other.prefix &&
         this.suffix == other.suffix &&
         DeepCollectionEquality.unordered().equals(this.phones, other.phones) &&
@@ -190,7 +185,6 @@ class Contact {
       this.identifier,
       this.jobTitle,
       this.middleName,
-      this.note,
       this.prefix,
       this.suffix
     ].where((s) => s != null));


### PR DESCRIPTION
Getting notes from a contact is disabled in iOS 13, which breaks the current getContacts() method. These changes remove the notes attribute fetching, so the method returns normally again.