### PR TITLE
Fixed swift_version error

### DIFF
--- a/ios/contacts_service.podspec
+++ b/ios/contacts_service.podspec
@@ -17,5 +17,6 @@ A new Flutter plugin.
   s.dependency 'Flutter'
   
   s.ios.deployment_target = '8.0'
+  s.swift_version       = '4.2'
 end
 


### PR DESCRIPTION
> [!] Unable to determine Swift version for the following pods:
>     - contacts_service does not specify a Swift version and none of the targets (Runner) integrating it have the SWIFT_VERSION attribute set. Please contact the author or set the SWIFT_VERSION attribute in at least one of the targets that integrate this pod.

Adding a swift version fixes the error above and pod install works fine now.