### PR TITLE
Adds `getAvatar()` method channel API for Android.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.3.5] - October 17, 2019
+
+* Added `getAvatars()` API to lazily retrieve contact avatars.
+  * Only implemented for Android.
+
 ## [0.3.4] - September 21, 2019
   
 * Fix Contact.java comparison to guard NPEs (@creativepsyco)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [0.3.5] - October 17, 2019
 
-* Added `getAvatars()` API to lazily retrieve contact avatars.
+* Added `getAvatar()` API to lazily retrieve contact avatars.
   * Only implemented for Android.
 
 ## [0.3.4] - September 21, 2019

--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ import 'package:contacts_service/contacts_service.dart';
 // Get all contacts on device
 Iterable<Contact> contacts = await ContactsService.getContacts();  
 
-// Get all contacts without thumbnail(faster)
+// Get all contacts without thumbnail (faster)
 Iterable<Contact> contacts = await ContactsService.getContacts(withThumbnails: false);
+
+// Get thumbnails for avatars afterwards (only necessary if `withThumbnails: false` is used)
+Iterable<Uint8List> avatars = await ContactsService.getAvatars(contacts.map((c) => c.identifier));
   
 // Get contacts matching a string
 Iterable<Contact> johns = await ContactsService.getContacts(query : "john");

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Iterable<Contact> contacts = await ContactsService.getContacts();
 // Get all contacts without thumbnail (faster)
 Iterable<Contact> contacts = await ContactsService.getContacts(withThumbnails: false);
 
-// Get thumbnails for avatars afterwards (only necessary if `withThumbnails: false` is used)
-Iterable<Uint8List> avatars = await ContactsService.getAvatars(contacts.map((c) => c.identifier));
+// Get thumbnail for an avatar afterwards (only necessary if `withThumbnails: false` is used)
+Uint8List avatar = await ContactsService.getAvatar(contact);
   
 // Get contacts matching a string
 Iterable<Contact> johns = await ContactsService.getContacts(query : "john");

--- a/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
+++ b/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
@@ -20,7 +20,7 @@ import android.os.Build;
 import android.provider.BaseColumns;
 import android.provider.ContactsContract;
 import android.text.TextUtils;
-import io.flutter.Log;
+import android.util.Log;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;

--- a/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
+++ b/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
@@ -20,6 +20,7 @@ import android.os.Build;
 import android.provider.BaseColumns;
 import android.provider.ContactsContract;
 import android.text.TextUtils;
+import io.flutter.Log;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -42,6 +43,7 @@ public class ContactsServicePlugin implements MethodCallHandler {
     this.contentResolver = contentResolver;
   }
 
+  private static final String LOG_TAG = "flutter_contacts";
   private final ContentResolver contentResolver;
 
   public static void registerWith(Registrar registrar) {
@@ -58,8 +60,8 @@ public class ContactsServicePlugin implements MethodCallHandler {
       case "getContactsForPhone":
         this.getContactsForPhone((String)call.argument("phone"), (boolean)call.argument("withThumbnails"), (boolean)call.argument("photoHighResolution"), (boolean)call.argument("orderByGivenName"), result);
         break;
-      case "getAvatarForContacts":
-        this.getAvatarForContacts((List<String>)call.argument("identifiers"), (boolean)call.argument("photoHighResolution"), result);
+      case "getAvatars":
+        this.getAvatars((List<String>)call.argument("identifiers"), (boolean)call.argument("photoHighResolution"), result);
         break;
       case "addContact":
         Contact c = Contact.fromMap((HashMap)call.arguments);
@@ -319,7 +321,7 @@ public class ContactsServicePlugin implements MethodCallHandler {
     }
   }
 
-  private void getAvatarForContacts(final List<String> identifiers, final boolean highRes,
+  private void getAvatars(final List<String> identifiers, final boolean highRes,
       final Result result) {
     new GetAvatarsTask(identifiers, highRes, contentResolver, result).execute();
   }
@@ -358,21 +360,21 @@ public class ContactsServicePlugin implements MethodCallHandler {
   private static byte[] loadContactPhotoHighRes(final String identifier,
       final boolean photoHighResolution, final ContentResolver contentResolver) {
     try {
-      Uri uri = ContentUris.withAppendedId(ContactsContract.Contacts.CONTENT_URI, Long.parseLong(identifier));
-      InputStream input = ContactsContract.Contacts.openContactPhotoInputStream(contentResolver, uri, photoHighResolution);
+      final Uri uri = ContentUris.withAppendedId(ContactsContract.Contacts.CONTENT_URI, Long.parseLong(identifier));
+      final InputStream input = ContactsContract.Contacts.openContactPhotoInputStream(contentResolver, uri, photoHighResolution);
 
       if (input == null) return null;
 
-      Bitmap bitmap = BitmapFactory.decodeStream(input);
+      final Bitmap bitmap = BitmapFactory.decodeStream(input);
       input.close();
 
-      ByteArrayOutputStream stream = new ByteArrayOutputStream();
+      final ByteArrayOutputStream stream = new ByteArrayOutputStream();
       bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
       final byte[] bytes = stream.toByteArray();
       stream.close();
       return bytes;
-    } catch (IOException e){
-      e.printStackTrace();
+    } catch (final IOException ex){
+      Log.e(LOG_TAG, ex.getMessage());
       return null;
     }
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -46,13 +46,13 @@ class _ContactListPageState extends State<ContactListPage> {
       });
 
       // Lazy load thumbnails after rendering initial contacts.
-      final avatars = (await ContactsService.getAvatarForContacts(
+      final avatars = (await ContactsService.getAvatars(
           contacts.map((c) => c.identifier))).toList();
-      for (var i = 0; i < contacts.length; ++i) {
-        setState(() {
+      setState(() {
+        for (var i = 0; i < contacts.length; ++i) {
           contacts[i].avatar = avatars[i];
-        });
-      }
+        }
+      });
     } else {
       _handleInvalidPermissions(permissionStatus);
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -46,13 +46,12 @@ class _ContactListPageState extends State<ContactListPage> {
       });
 
       // Lazy load thumbnails after rendering initial contacts.
-      final avatars = (await ContactsService.getAvatars(
-          contacts.map((c) => c.identifier))).toList();
-      setState(() {
-        for (var i = 0; i < contacts.length; ++i) {
-          contacts[i].avatar = avatars[i];
-        }
-      });
+      for (final contact in contacts) {
+        ContactsService.getAvatar(contact).then((avatar) {
+          if (avatar == null) return; // Don't redraw if no change.
+          setState(() => contact.avatar = avatar);
+        });
+      }
     } else {
       _handleInvalidPermissions(permissionStatus);
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -25,7 +25,7 @@ class ContactListPage extends StatefulWidget {
 }
 
 class _ContactListPageState extends State<ContactListPage> {
-  Iterable<Contact> _contacts;
+  List<Contact> _contacts;
 
   @override
   initState() {
@@ -36,11 +36,23 @@ class _ContactListPageState extends State<ContactListPage> {
   refreshContacts() async {
     PermissionStatus permissionStatus = await _getContactPermission();
     if (permissionStatus == PermissionStatus.granted) {
-      var contacts = await ContactsService.getContacts();
-//      var contacts = await ContactsService.getContactsForPhone("8554964652");
+      // Load without thumbnails initially.
+      var contacts = (await ContactsService.getContacts(withThumbnails: false))
+          .toList();
+//      var contacts = (await ContactsService.getContactsForPhone("8554964652"))
+//          .toList();
       setState(() {
         _contacts = contacts;
       });
+
+      // Lazy load thumbnails after rendering initial contacts.
+      final avatars = (await ContactsService.getAvatarForContacts(
+          contacts.map((c) => c.identifier))).toList();
+      for (var i = 0; i < contacts.length; ++i) {
+        setState(() {
+          contacts[i].avatar = avatars[i];
+        });
+      }
     } else {
       _handleInvalidPermissions(permissionStatus);
     }

--- a/lib/contacts_service.dart
+++ b/lib/contacts_service.dart
@@ -46,13 +46,14 @@ class ContactsService {
     return contacts.map((m) => Contact.fromMap(m));
   }
 
-  /// Fetches the avatar for the contacts with the provided [identifiers].
-  /// Returns a list of avatars in the same order as the [identifiers] given.
-  /// If a user does not have an avatar, then `null` is returned in that slot.
-  static Future<Iterable<Uint8List>> getAvatarForContacts(
+  /// Fetches the avatar for each of the contacts with the provided
+  /// [identifiers]. Returns a list of avatars in the same order as the
+  /// [identifiers] given. If a user does not have an avatar, then `null` is
+  /// returned in that slot. Only implemented on Android.
+  static Future<Iterable<Uint8List>> getAvatars(
       final Iterable<String> identifiers, {final bool photoHighRes = true}) async {
     // Returns a List<_Uint8ArrayView>.
-    final list = await _channel.invokeMethod('getAvatarForContacts', <String, dynamic>{
+    final list = await _channel.invokeMethod('getAvatars', <String, dynamic>{
       'identifiers': identifiers.toList(),
       'photoHighResolution': photoHighRes,
     });

--- a/lib/contacts_service.dart
+++ b/lib/contacts_service.dart
@@ -46,6 +46,21 @@ class ContactsService {
     return contacts.map((m) => Contact.fromMap(m));
   }
 
+  /// Fetches the avatar for the contacts with the provided [identifiers].
+  /// Returns a list of avatars in the same order as the [identifiers] given.
+  /// If a user does not have an avatar, then `null` is returned in that slot.
+  static Future<Iterable<Uint8List>> getAvatarForContacts(
+      final Iterable<String> identifiers, {final bool photoHighRes = true}) async {
+    // Returns a List<_Uint8ArrayView>.
+    final list = await _channel.invokeMethod('getAvatarForContacts', <String, dynamic>{
+      'identifiers': identifiers.toList(),
+      'photoHighResolution': photoHighRes,
+    });
+
+    // Cast to a List<Uint8List> to avoid runtime type errors.
+    return list.map<Uint8List>((avatar) => avatar as Uint8List);
+  }
+
   /// Adds the [contact] to the device contact list
   static Future addContact(Contact contact) =>
       _channel.invokeMethod('addContact', Contact._toMap(contact));

--- a/lib/contacts_service.dart
+++ b/lib/contacts_service.dart
@@ -46,21 +46,15 @@ class ContactsService {
     return contacts.map((m) => Contact.fromMap(m));
   }
 
-  /// Fetches the avatar for each of the contacts with the provided
-  /// [identifiers]. Returns a list of avatars in the same order as the
-  /// [identifiers] given. If a user does not have an avatar, then `null` is
-  /// returned in that slot. Only implemented on Android.
-  static Future<Iterable<Uint8List>> getAvatars(
-      final Iterable<String> identifiers, {final bool photoHighRes = true}) async {
-    // Returns a List<_Uint8ArrayView>.
-    final list = await _channel.invokeMethod('getAvatars', <String, dynamic>{
-      'identifiers': identifiers.toList(),
-      'photoHighResolution': photoHighRes,
-    });
-
-    // Cast to a List<Uint8List> to avoid runtime type errors.
-    return list.map<Uint8List>((avatar) => avatar as Uint8List);
-  }
+  /// Loads the avatar for the given contact and returns it. If the user does
+  /// not have an avatar, then `null` is returned in that slot. Only implemented
+  /// on Android.
+  static Future<Uint8List> getAvatar(
+      final Contact contact, {final bool photoHighRes = true}) =>
+      _channel.invokeMethod('getAvatar', <String, dynamic>{
+        'contact': Contact._toMap(contact),
+        'photoHighResolution': photoHighRes,
+      });
 
   /// Adds the [contact] to the device contact list
   static Future addContact(Contact contact) =>

--- a/test/contacts_test.dart
+++ b/test/contacts_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:contacts_service/contacts_service.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -20,6 +22,12 @@ void main() {
           ]
         },
       ];
+    } else if (methodCall.method == 'getAvatarForContacts') {
+      return [
+        Uint8List.fromList([0, 1, 2, 3]),
+        null /* no avatar for contact */,
+        Uint8List.fromList([4, 5, 6, 7]),
+      ];
     }
     return null;
   });
@@ -35,6 +43,39 @@ void main() {
     expect(contacts.toList()[0].givenName, 'givenName1');
     expect(contacts.toList()[1].postalAddresses.toList()[0].label, 'label');
     expect(contacts.toList()[1].emails.toList()[0].label, 'label');
+  });
+
+  test('should get avatar for contact identifiers', () async {
+    final avatars = await ContactsService.getAvatarForContacts([
+      'first',
+      'second',
+      'third',
+    ]);
+
+    expect(log, <Matcher>[
+      isMethodCall('getAvatarForContacts', arguments: <String, dynamic>{
+        'identifiers': ['first', 'second', 'third'],
+        'photoHighResolution': true,
+      })
+    ]);
+
+    expect(avatars, [
+      Uint8List.fromList([0, 1, 2, 3]),
+      null,
+      Uint8List.fromList([4, 5, 6, 7]),
+    ]);
+  });
+
+  test('should get low-res avatar for contact identifiers', () async {
+    await ContactsService.getAvatarForContacts(
+        ['first', 'second', 'third'], photoHighRes: false);
+
+    expect(log, <Matcher>[
+      isMethodCall('getAvatarForContacts', arguments: <String, dynamic>{
+        'identifiers': ['first', 'second', 'third'],
+        'photoHighResolution': false,
+      })
+    ]);
   });
 
   test('should add contact', () async {

--- a/test/contacts_test.dart
+++ b/test/contacts_test.dart
@@ -22,12 +22,8 @@ void main() {
           ]
         },
       ];
-    } else if (methodCall.method == 'getAvatars') {
-      return [
-        Uint8List.fromList([0, 1, 2, 3]),
-        null /* no avatar for contact */,
-        Uint8List.fromList([4, 5, 6, 7]),
-      ];
+    } else if (methodCall.method == 'getAvatar') {
+      return Uint8List.fromList([0, 1, 2, 3]);
     }
     return null;
   });
@@ -46,33 +42,28 @@ void main() {
   });
 
   test('should get avatar for contact identifiers', () async {
-    final avatars = await ContactsService.getAvatars([
-      'first',
-      'second',
-      'third',
-    ]);
+    final contact = Contact(givenName: 'givenName');
+
+    final avatar = await ContactsService.getAvatar(contact);
 
     expect(log, <Matcher>[
-      isMethodCall('getAvatars', arguments: <String, dynamic>{
-        'identifiers': ['first', 'second', 'third'],
+      isMethodCall('getAvatar', arguments: <String, dynamic>{
+        'contact': contact.toMap(),
         'photoHighResolution': true,
       })
     ]);
 
-    expect(avatars, [
-      Uint8List.fromList([0, 1, 2, 3]),
-      null,
-      Uint8List.fromList([4, 5, 6, 7]),
-    ]);
+    expect(avatar, Uint8List.fromList([0, 1, 2, 3]));
   });
 
   test('should get low-res avatar for contact identifiers', () async {
-    await ContactsService.getAvatars(
-        ['first', 'second', 'third'], photoHighRes: false);
+    final contact = Contact(givenName: 'givenName');
+
+    await ContactsService.getAvatar(contact, photoHighRes: false);
 
     expect(log, <Matcher>[
-      isMethodCall('getAvatars', arguments: <String, dynamic>{
-        'identifiers': ['first', 'second', 'third'],
+      isMethodCall('getAvatar', arguments: <String, dynamic>{
+        'contact': contact.toMap(),
         'photoHighResolution': false,
       })
     ]);

--- a/test/contacts_test.dart
+++ b/test/contacts_test.dart
@@ -22,7 +22,7 @@ void main() {
           ]
         },
       ];
-    } else if (methodCall.method == 'getAvatarForContacts') {
+    } else if (methodCall.method == 'getAvatars') {
       return [
         Uint8List.fromList([0, 1, 2, 3]),
         null /* no avatar for contact */,
@@ -46,14 +46,14 @@ void main() {
   });
 
   test('should get avatar for contact identifiers', () async {
-    final avatars = await ContactsService.getAvatarForContacts([
+    final avatars = await ContactsService.getAvatars([
       'first',
       'second',
       'third',
     ]);
 
     expect(log, <Matcher>[
-      isMethodCall('getAvatarForContacts', arguments: <String, dynamic>{
+      isMethodCall('getAvatars', arguments: <String, dynamic>{
         'identifiers': ['first', 'second', 'third'],
         'photoHighResolution': true,
       })
@@ -67,11 +67,11 @@ void main() {
   });
 
   test('should get low-res avatar for contact identifiers', () async {
-    await ContactsService.getAvatarForContacts(
+    await ContactsService.getAvatars(
         ['first', 'second', 'third'], photoHighRes: false);
 
     expect(log, <Matcher>[
-      isMethodCall('getAvatarForContacts', arguments: <String, dynamic>{
+      isMethodCall('getAvatars', arguments: <String, dynamic>{
         'identifiers': ['first', 'second', 'third'],
         'photoHighResolution': false,
       })


### PR DESCRIPTION
Implements #43 for Android.

I added a `getAvatarForContacts()` API to the method channel. This allows callers to load avatars directly. `getContacts()` already supports `withThumbnails: false`, so users can avoid loading them initially with that flag and use `getAvatarForContacts()` to load them later when desired. I used this pattern in the example app just to show basic usage.

To explain some of the design decisions:

1. `getAvatarForContacts()` has this weird name because I wanted to be clear that it works with multiple contacts, but each contact only has one avatar.
1. `getAvatarForContacts()` returns `null` for any contact lacking an avatar. This is different from `getContacts()` which returns an empty `byte[]`. I felt this was a little bit better, but didn't change `getContacts()` to avoid introducing a breaking change. Let me know if anyone has strong feelings about returning `null` or an empty `byte[]` in both circumstances.
1. This API supports looking up multiple contacts at once, which is hopefully better for bulk use cases. I'm not very familiar with `MethodChannel`, so I don't know the performance implications of using it, but it seemed more reasonable to pass n avatars through a single channel (and a single `AsyncTask`) rather than 1 avatar at at time through n channels (and n `AsyncTasks`). Of course, users can also provide just a single contact identifier at a time if they really do want the behavior of looking up contact avatars one at a time.