### PR TITLE
Expose raw account type and account name on Android.

### DIFF
--- a/android/src/main/java/flutter/plugins/contactsservice/contactsservice/Contact.java
+++ b/android/src/main/java/flutter/plugins/contactsservice/contactsservice/Contact.java
@@ -13,7 +13,7 @@ public class Contact implements Comparable<Contact> {
     }
 
     String identifier;
-    String displayName, givenName, middleName, familyName, prefix, suffix, company, jobTitle, note, birthday, androidAccountType;
+    String displayName, givenName, middleName, familyName, prefix, suffix, company, jobTitle, note, birthday, androidAccountType, androidAccountName;
     ArrayList<Item> emails = new ArrayList<>();
     ArrayList<Item> phones = new ArrayList<>();
     ArrayList<PostalAddress> postalAddresses = new ArrayList<>();
@@ -34,6 +34,7 @@ public class Contact implements Comparable<Contact> {
         contactMap.put("note", note);
         contactMap.put("birthday", birthday);
         contactMap.put("androidAccountType", androidAccountType);
+        contactMap.put("androidAccountName", androidAccountName);
 
         ArrayList<HashMap<String, String>> emailsMap = new ArrayList<>();
         for (Item email : emails) {
@@ -71,6 +72,7 @@ public class Contact implements Comparable<Contact> {
         contact.note = (String) map.get("note");
         contact.birthday = (String) map.get("birthday");
         contact.androidAccountType = (String) map.get("androidAccountType");
+        contact.androidAccountName = (String) map.get("androidAccountName");
 
         ArrayList<HashMap> emails = (ArrayList<HashMap>) map.get("emails");
         if (emails != null) {

--- a/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
+++ b/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
@@ -107,6 +107,7 @@ public class ContactsServicePlugin implements MethodCallHandler {
                   ContactsContract.Profile.DISPLAY_NAME,
                   ContactsContract.Contacts.Data.MIMETYPE,
                   ContactsContract.RawContacts.ACCOUNT_TYPE,
+                  ContactsContract.RawContacts.ACCOUNT_NAME,
                   StructuredName.DISPLAY_NAME,
                   StructuredName.GIVEN_NAME,
                   StructuredName.MIDDLE_NAME,
@@ -272,6 +273,7 @@ public class ContactsServicePlugin implements MethodCallHandler {
       String mimeType = cursor.getString(cursor.getColumnIndex(ContactsContract.Data.MIMETYPE));
       contact.displayName = cursor.getString(cursor.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME));
       contact.androidAccountType = cursor.getString(cursor.getColumnIndex(ContactsContract.RawContacts.ACCOUNT_TYPE));
+      contact.androidAccountName = cursor.getString(cursor.getColumnIndex(ContactsContract.RawContacts.ACCOUNT_NAME));
 
       //NAMES
       if (mimeType.equals(CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE)) {

--- a/lib/contacts_service.dart
+++ b/lib/contacts_service.dart
@@ -85,9 +85,12 @@ class Contact {
     this.avatar,
     this.birthday,
     this.androidAccountType,
+    this.androidAccountTypeRaw,
+    this.androidAccountName,
   });
 
   String identifier, displayName, givenName, middleName, prefix, suffix, familyName, company, jobTitle;
+  String androidAccountTypeRaw, androidAccountName;
   AndroidAccountType androidAccountType;
   Iterable<Item> emails = [];
   Iterable<Item> phones = [];
@@ -111,7 +114,9 @@ class Contact {
     suffix = m["suffix"];
     company = m["company"];
     jobTitle = m["jobTitle"];
-    androidAccountType = accountTypeFromString(m["androidAccountType"]);
+    androidAccountTypeRaw = m["androidAccountType"];
+    androidAccountType = accountTypeFromString(androidAccountTypeRaw);
+    androidAccountName = m["androidAccountName"];
     emails = (m["emails"] as Iterable)?.map((m) => Item.fromMap(m));
     phones = (m["phones"] as Iterable)?.map((m) => Item.fromMap(m));
     postalAddresses = (m["postalAddresses"] as Iterable)
@@ -152,7 +157,8 @@ class Contact {
       "suffix": contact.suffix,
       "company": contact.company,
       "jobTitle": contact.jobTitle,
-      "androidAccountType": (contact.androidAccountType != null) ? contact.androidAccountType.toString() : null,
+      "androidAccountType": contact.androidAccountTypeRaw, 
+      "androidAccountName": contact.androidAccountName,
       "emails": emails,
       "phones": phones,
       "postalAddresses": postalAddresses,
@@ -175,6 +181,7 @@ class Contact {
       company: this.company ?? other.company,
       jobTitle: this.jobTitle ?? other.jobTitle,
       androidAccountType: this.androidAccountType ?? other.androidAccountType,
+      androidAccountName: this.androidAccountName ?? other.androidAccountName,
       emails: this.emails == null
           ? other.emails
           : this.emails.toSet().union(other.emails?.toSet() ?? Set()).toList(),
@@ -204,6 +211,7 @@ class Contact {
         this.identifier == other.identifier &&
         this.jobTitle == other.jobTitle &&
         this.androidAccountType == other.androidAccountType &&
+        this.androidAccountName == other.androidAccountName &&
         this.middleName == other.middleName &&
         this.prefix == other.prefix &&
         this.suffix == other.suffix &&
@@ -224,6 +232,7 @@ class Contact {
       this.identifier,
       this.jobTitle,
       this.androidAccountType,
+      this.androidAccountName,
       this.middleName,
       this.prefix,
       this.suffix,

--- a/test/contacts_test.dart
+++ b/test/contacts_test.dart
@@ -188,6 +188,7 @@ void main() {
       "company": null,
       "jobTitle": null,
       "androidAccountType": null,
+      "androidAccountName": null,
       "emails": [],
       "phones": [],
       "postalAddresses": [],
@@ -212,6 +213,7 @@ void expectMethodCall(List<MethodCall> log, String methodName) {
         'company': null,
         'jobTitle': null,
         'androidAccountType': null,
+        'androidAccountName': null,
         'emails': [
           {'label': 'label', 'value': null}
         ],


### PR DESCRIPTION
Expose the raw account type (e.g. "com.google" or "com.skype") and account name on Android.

That way we can distinguish between different types of "other" accounts, as well as different accounts of the same type, such as two different gmail accounts.