### PR TITLE
Fix slowness in get contact for iOS 11+

### DIFF
--- a/ios/Classes/SwiftContactsServicePlugin.swift
+++ b/ios/Classes/SwiftContactsServicePlugin.swift
@@ -82,13 +82,22 @@ public class SwiftContactsServicePlugin: NSObject, FlutterPlugin {
         if query != nil && !phoneQuery {
             fetchRequest.predicate = CNContact.predicateForContacts(matchingName: query!)
         }
-        
+
+        if #available(iOS 11, *) {
+            if query != nil && phoneQuery {
+                let phoneNumberPredicate = CNPhoneNumber(stringValue: query!)
+                fetchRequest.predicate = CNContact.predicateForContacts(matching: phoneNumberPredicate)
+            }
+        }
+
         // Fetch contacts
         do{
             try store.enumerateContacts(with: fetchRequest, usingBlock: { (contact, stop) -> Void in
 
                 if phoneQuery {
-                    if query != nil && self.has(contact: contact, phone: query!){
+                    if #available(iOS 11, *) {
+                        contacts.append(contact)
+                    } else if query != nil && self.has(contact: contact, phone: query!){
                         contacts.append(contact)
                     }
                 } else {

--- a/test/contacts_test.dart
+++ b/test/contacts_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   const MethodChannel channel = MethodChannel('github.com/clovisnicolas/flutter_contacts');
   final List<MethodCall> log = <MethodCall>[];
   channel.setMockMethodCallHandler((MethodCall methodCall) async {


### PR DESCRIPTION
Fixing getContacts with phoneQuery to use predicates which are available from iOS 11

Issue reference - #57 , #70 

Resource -

[Predicate for Contacts](https://developer.apple.com/documentation/contacts/cncontact/3020510-predicateforcontacts) 