### PR TITLE
Add openDeviceContactPicker functionality

### DIFF
--- a/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
+++ b/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
@@ -1,12 +1,5 @@
 package flutter.plugins.contactsservice.contactsservice;
 
-import static android.provider.ContactsContract.CommonDataKinds;
-import static android.provider.ContactsContract.CommonDataKinds.Email;
-import static android.provider.ContactsContract.CommonDataKinds.Organization;
-import static android.provider.ContactsContract.CommonDataKinds.Phone;
-import static android.provider.ContactsContract.CommonDataKinds.StructuredName;
-import static android.provider.ContactsContract.CommonDataKinds.StructuredPostal;
-
 import android.annotation.TargetApi;
 import android.content.ContentProviderOperation;
 import android.content.ContentResolver;
@@ -21,9 +14,23 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.provider.BaseColumns;
 import android.provider.ContactsContract;
-import android.provider.ContactsContract.RawContacts;
 import android.text.TextUtils;
 import android.util.Log;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
@@ -34,18 +41,14 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+
+import static android.app.Activity.RESULT_CANCELED;
+import static android.provider.ContactsContract.CommonDataKinds;
+import static android.provider.ContactsContract.CommonDataKinds.Email;
+import static android.provider.ContactsContract.CommonDataKinds.Organization;
+import static android.provider.ContactsContract.CommonDataKinds.Phone;
+import static android.provider.ContactsContract.CommonDataKinds.StructuredName;
+import static android.provider.ContactsContract.CommonDataKinds.StructuredPostal;
 
 @TargetApi(Build.VERSION_CODES.ECLAIR)
 public class ContactsServicePlugin implements MethodCallHandler, FlutterPlugin, ActivityAware {
@@ -95,10 +98,10 @@ public class ContactsServicePlugin implements MethodCallHandler, FlutterPlugin, 
   public void onMethodCall(MethodCall call, Result result) {
     switch(call.method){
       case "getContacts": {
-        this.getContacts((String)call.argument("query"), (boolean)call.argument("withThumbnails"), (boolean)call.argument("photoHighResolution"), (boolean)call.argument("orderByGivenName"), result);
+        this.getContacts(call.method, (String)call.argument("query"), (boolean)call.argument("withThumbnails"), (boolean)call.argument("photoHighResolution"), (boolean)call.argument("orderByGivenName"), result);
         break;
       } case "getContactsForPhone": {
-        this.getContactsForPhone((String)call.argument("phone"), (boolean)call.argument("withThumbnails"), (boolean)call.argument("photoHighResolution"), (boolean)call.argument("orderByGivenName"), result);
+        this.getContactsForPhone(call.method, (String)call.argument("phone"), (boolean)call.argument("withThumbnails"), (boolean)call.argument("photoHighResolution"), (boolean)call.argument("orderByGivenName"), result);
         break;
       } case "getAvatar": {
         final Contact contact = Contact.fromMap((HashMap)call.argument("contact"));
@@ -145,6 +148,9 @@ public class ContactsServicePlugin implements MethodCallHandler, FlutterPlugin, 
           result.success(FORM_COULD_NOT_BE_OPEN);
         }
         break;
+      } case "openDeviceContactPicker": {
+        openDeviceContactPicker(result);
+        break;
       } default: {
         result.notImplemented();
         break;
@@ -189,12 +195,12 @@ public class ContactsServicePlugin implements MethodCallHandler, FlutterPlugin, 
 
 
   @TargetApi(Build.VERSION_CODES.ECLAIR)
-  private void getContacts(String query, boolean withThumbnails, boolean photoHighResolution, boolean orderByGivenName, Result result) {
-    new GetContactsTask(result, withThumbnails, photoHighResolution, orderByGivenName).executeOnExecutor(executor, query, false);
+  private void getContacts(String callMethod, String query, boolean withThumbnails, boolean photoHighResolution, boolean orderByGivenName, Result result) {
+    new GetContactsTask(callMethod, result, withThumbnails, photoHighResolution, orderByGivenName).executeOnExecutor(executor, query, false);
   }
 
-  private void getContactsForPhone(String phone, boolean withThumbnails, boolean photoHighResolution, boolean orderByGivenName, Result result) {
-    new GetContactsTask(result, withThumbnails, photoHighResolution, orderByGivenName).executeOnExecutor(executor, phone, true);
+  private void getContactsForPhone(String callMethod, String phone, boolean withThumbnails, boolean photoHighResolution, boolean orderByGivenName, Result result) {
+    new GetContactsTask(callMethod, result, withThumbnails, photoHighResolution, orderByGivenName).executeOnExecutor(executor, phone, true);
   }
 
   @Override
@@ -228,6 +234,7 @@ public class ContactsServicePlugin implements MethodCallHandler, FlutterPlugin, 
   private class BaseContactsServiceDelegate implements PluginRegistry.ActivityResultListener {
     private static final int REQUEST_OPEN_CONTACT_FORM = 52941;
     private static final int REQUEST_OPEN_EXISTING_CONTACT = 52942;
+    private static final int REQUEST_OPEN_CONTACT_PICKER = 52943;
     private Result result;
 
     void setResult(Result result) {
@@ -251,9 +258,27 @@ public class ContactsServicePlugin implements MethodCallHandler, FlutterPlugin, 
           finishWithResult(FORM_OPERATION_CANCELED);
         }
         return true;
-      } else {
-        finishWithResult(FORM_COULD_NOT_BE_OPEN);
       }
+
+      if (requestCode == REQUEST_OPEN_CONTACT_PICKER) {
+        if (resultCode == RESULT_CANCELED) {
+          finishWithResult(FORM_OPERATION_CANCELED);
+          return true;
+        }
+        Uri contactUri = intent.getData();
+        Cursor cursor = contentResolver.query(contactUri, null, null, null, null);
+        if (cursor.moveToFirst()) {
+          String id = contactUri.getLastPathSegment();
+          getContacts("openDeviceContactPicker", id, false, false, false, this.result);
+        } else {
+          Log.e(LOG_TAG, "onActivityResult - cursor.moveToFirst() returns false");
+          finishWithResult(FORM_OPERATION_CANCELED);
+        }
+        cursor.close();
+        return true;
+      }
+
+      finishWithResult(FORM_COULD_NOT_BE_OPEN);
       return false;
     }
 
@@ -284,6 +309,12 @@ public class ContactsServicePlugin implements MethodCallHandler, FlutterPlugin, 
       }
     }
 
+    void openContactPicker() {
+        Intent intent = new Intent(Intent.ACTION_PICK);
+        intent.setType(ContactsContract.Contacts.CONTENT_TYPE);
+        startIntent(intent, REQUEST_OPEN_CONTACT_PICKER);
+    }
+
     void startIntent(Intent intent, int request) {
     }
 
@@ -310,7 +341,16 @@ public class ContactsServicePlugin implements MethodCallHandler, FlutterPlugin, 
       return null;
     }
   }
-
+  
+    private void openDeviceContactPicker(Result result) {
+      if (delegate != null) {
+        delegate.setResult(result);
+        delegate.openContactPicker();
+      } else {
+        result.success(FORM_COULD_NOT_BE_OPEN);
+      }
+  }
+  
   private class ContactServiceDelegateOld extends BaseContactsServiceDelegate {
     private final PluginRegistry.Registrar registrar;
 
@@ -350,7 +390,11 @@ public class ContactsServicePlugin implements MethodCallHandler, FlutterPlugin, 
     @Override
     void startIntent(Intent intent, int request) {
       if (this.activityPluginBinding != null) {
-        activityPluginBinding.getActivity().startActivityForResult(intent, request);
+        if (intent.resolveActivity(context.getPackageManager()) != null) {
+          activityPluginBinding.getActivity().startActivityForResult(intent, request);
+        } else {
+          finishWithResult(FORM_COULD_NOT_BE_OPEN);
+        }
       } else {
         context.startActivity(intent);
       }
@@ -360,12 +404,14 @@ public class ContactsServicePlugin implements MethodCallHandler, FlutterPlugin, 
   @TargetApi(Build.VERSION_CODES.CUPCAKE)
   private class GetContactsTask extends AsyncTask<Object, Void, ArrayList<HashMap>> {
 
+    private String callMethod;
     private Result getContactResult;
     private boolean withThumbnails;
     private boolean photoHighResolution;
     private boolean orderByGivenName;
 
-    public GetContactsTask(Result result, boolean withThumbnails, boolean photoHighResolution, boolean orderByGivenName){
+    public GetContactsTask(String callMethod, Result result, boolean withThumbnails, boolean photoHighResolution, boolean orderByGivenName){
+      this.callMethod = callMethod;
       this.getContactResult = result;
       this.withThumbnails = withThumbnails;
       this.photoHighResolution = photoHighResolution;
@@ -375,10 +421,12 @@ public class ContactsServicePlugin implements MethodCallHandler, FlutterPlugin, 
     @TargetApi(Build.VERSION_CODES.ECLAIR)
     protected ArrayList<HashMap> doInBackground(Object... params) {
       ArrayList<Contact> contacts;
-      if ((Boolean) params[1])
-        contacts = getContactsFrom(getCursorForPhone(((String) params[0])));
-      else
-        contacts = getContactsFrom(getCursor(((String) params[0])));
+      switch (callMethod) {
+        case "openDeviceContactPicker": contacts = getContactsFrom(getCursor(null, (String) params[0])); break;
+        case "getContacts": contacts = getContactsFrom(getCursor((String) params[0], null)); break;
+        case "getContactsForPhone": contacts = getContactsFrom(getCursorForPhone(((String) params[0]))); break;
+        default: return null;
+      }
 
       if (withThumbnails) {
         for(Contact c : contacts){
@@ -418,26 +466,33 @@ public class ContactsServicePlugin implements MethodCallHandler, FlutterPlugin, 
     }
 
     protected void onPostExecute(ArrayList<HashMap> result) {
-      getContactResult.success(result);
+      if (result == null) {
+        getContactResult.notImplemented();
+      } else {
+        getContactResult.success(result);
+      }
     }
   }
 
 
-  private Cursor getCursor(String query) {
-    String selection = ContactsContract.Data.MIMETYPE + "=? OR " + ContactsContract.Data.MIMETYPE + "=? OR "
+  private Cursor getCursor(String query, String rawContactId) {
+    String selection = "(" + ContactsContract.Data.MIMETYPE + "=? OR " + ContactsContract.Data.MIMETYPE + "=? OR "
             + ContactsContract.Data.MIMETYPE + "=? OR " + ContactsContract.Data.MIMETYPE + "=? OR "
             + ContactsContract.Data.MIMETYPE + "=? OR " + ContactsContract.Data.MIMETYPE + "=? OR "
-            + ContactsContract.Data.MIMETYPE + "=? OR " + ContactsContract.RawContacts.ACCOUNT_TYPE + "=?";
-    String[] selectionArgs = new String[] { CommonDataKinds.Note.CONTENT_ITEM_TYPE, Email.CONTENT_ITEM_TYPE,
+            + ContactsContract.Data.MIMETYPE + "=? OR " + ContactsContract.RawContacts.ACCOUNT_TYPE + "=?" + ")";
+    ArrayList<String> selectionArgs = new ArrayList<>(Arrays.asList(CommonDataKinds.Note.CONTENT_ITEM_TYPE, Email.CONTENT_ITEM_TYPE,
             Phone.CONTENT_ITEM_TYPE, StructuredName.CONTENT_ITEM_TYPE, Organization.CONTENT_ITEM_TYPE,
-            StructuredPostal.CONTENT_ITEM_TYPE, CommonDataKinds.Event.CONTENT_ITEM_TYPE, ContactsContract.RawContacts.ACCOUNT_TYPE
-    };
-    if(query != null){
-      selectionArgs = new String[]{query + "%"};
+            StructuredPostal.CONTENT_ITEM_TYPE, CommonDataKinds.Event.CONTENT_ITEM_TYPE, ContactsContract.RawContacts.ACCOUNT_TYPE));
+    if (query != null) {
+      selectionArgs = new ArrayList<>();
+      selectionArgs.add(query + "%");
       selection = ContactsContract.Contacts.DISPLAY_NAME_PRIMARY + " LIKE ?";
     }
-
-    return contentResolver.query(ContactsContract.Data.CONTENT_URI, PROJECTION, selection, selectionArgs, null);
+    if (rawContactId != null) {
+      selectionArgs.add(rawContactId);
+      selection += " AND " + ContactsContract.Data.CONTACT_ID + " =?";
+    }
+    return contentResolver.query(ContactsContract.Data.CONTENT_URI, PROJECTION, selection, selectionArgs.toArray(new String[selectionArgs.size()]), null);
   }
 
   private Cursor getCursorForPhone(String phone) {
@@ -830,6 +885,9 @@ public class ContactsServicePlugin implements MethodCallHandler, FlutterPlugin, 
       contentResolver.applyBatch(ContactsContract.AUTHORITY, ops);
       return true;
     } catch (Exception e) {
+      // Log exception
+      Log.e("TAG", "Exception encountered while inserting contact: " );
+      e.printStackTrace();
       return false;
     }
   }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>fr</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -25,7 +25,7 @@
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>NSContactsUsageDescription</key>
-    <string>This app requires contacts access to function properly.</string>
+	<string>This app requires contacts access to function properly.</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/example/lib/contacts_list_page.dart
+++ b/example/lib/contacts_list_page.dart
@@ -1,0 +1,537 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:contacts_service_example/main.dart';
+
+import 'package:contacts_service/contacts_service.dart';
+import 'package:intl/intl.dart';
+
+class ContactListPage extends StatefulWidget {
+  @override
+  _ContactListPageState createState() => _ContactListPageState();
+}
+
+class _ContactListPageState extends State<ContactListPage> {
+  List<Contact> _contacts;
+
+  @override
+  void initState() {
+    super.initState();
+    refreshContacts();
+  }
+
+  Future<void> refreshContacts() async {
+    // Load without thumbnails initially.
+    var contacts = (await ContactsService.getContacts(
+            withThumbnails: false, iOSLocalizedLabels: iOSLocalizedLabels))
+        .toList();
+//      var contacts = (await ContactsService.getContactsForPhone("8554964652"))
+//          .toList();
+    setState(() {
+      _contacts = contacts;
+    });
+
+    // Lazy load thumbnails after rendering initial contacts.
+    for (final contact in contacts) {
+      ContactsService.getAvatar(contact).then((avatar) {
+        if (avatar == null) return; // Don't redraw if no change.
+        setState(() => contact.avatar = avatar);
+      });
+    }
+  }
+
+  void updateContact() async {
+    Contact ninja = _contacts
+        .toList()
+        .firstWhere((contact) => contact.familyName.startsWith("Ninja"));
+    ninja.avatar = null;
+    await ContactsService.updateContact(ninja);
+
+    refreshContacts();
+  }
+
+  _openContactForm() async {
+    try {
+      var contact = await ContactsService.openContactForm(
+          iOSLocalizedLabels: iOSLocalizedLabels);
+      refreshContacts();
+    } on FormOperationException catch (e) {
+      switch (e.errorCode) {
+        case FormOperationErrorCode.FORM_OPERATION_CANCELED:
+        case FormOperationErrorCode.FORM_COULD_NOT_BE_OPEN:
+        case FormOperationErrorCode.FORM_OPERATION_UNKNOWN_ERROR:
+        default:
+          print(e.errorCode);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          'Contacts Plugin Example',
+        ),
+        actions: <Widget>[
+          IconButton(
+            icon: Icon(Icons.create),
+            onPressed: _openContactForm,
+          )
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        child: Icon(Icons.add),
+        onPressed: () {
+          Navigator.of(context).pushNamed("/add").then((_) {
+            refreshContacts();
+          });
+        },
+      ),
+      body: SafeArea(
+        child: _contacts != null
+            ? ListView.builder(
+                itemCount: _contacts?.length ?? 0,
+                itemBuilder: (BuildContext context, int index) {
+                  Contact c = _contacts?.elementAt(index);
+                  return ListTile(
+                    onTap: () {
+                      Navigator.of(context).push(MaterialPageRoute(
+                          builder: (BuildContext context) => ContactDetailsPage(
+                                c,
+                                onContactDeviceSave:
+                                    contactOnDeviceHasBeenUpdated,
+                              )));
+                    },
+                    leading: (c.avatar != null && c.avatar.length > 0)
+                        ? CircleAvatar(backgroundImage: MemoryImage(c.avatar))
+                        : CircleAvatar(child: Text(c.initials())),
+                    title: Text(c.displayName ?? ""),
+                  );
+                },
+              )
+            : Center(
+                child: CircularProgressIndicator(),
+              ),
+      ),
+    );
+  }
+
+  void contactOnDeviceHasBeenUpdated(Contact contact) {
+    this.setState(() {
+      var id = _contacts.indexWhere((c) => c.identifier == contact.identifier);
+      _contacts[id] = contact;
+    });
+  }
+}
+
+class ContactDetailsPage extends StatelessWidget {
+  ContactDetailsPage(this._contact, {this.onContactDeviceSave});
+
+  final Contact _contact;
+  final Function(Contact) onContactDeviceSave;
+
+  _openExistingContactOnDevice(BuildContext context) async {
+    try {
+      var contact = await ContactsService.openExistingContact(_contact,
+          iOSLocalizedLabels: iOSLocalizedLabels);
+      print(contact.emails.first.label);
+      if (onContactDeviceSave != null) {
+        onContactDeviceSave(contact);
+      }
+      Navigator.of(context).pop();
+    } on FormOperationException catch (e) {
+      switch (e.errorCode) {
+        case FormOperationErrorCode.FORM_OPERATION_CANCELED:
+        case FormOperationErrorCode.FORM_COULD_NOT_BE_OPEN:
+        case FormOperationErrorCode.FORM_OPERATION_UNKNOWN_ERROR:
+        default:
+          print(e.toString());
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_contact.displayName ?? ""),
+        actions: <Widget>[
+//          IconButton(
+//            icon: Icon(Icons.share),
+//            onPressed: () => shareVCFCard(context, contact: _contact),
+//          ),
+          IconButton(
+            icon: Icon(Icons.delete),
+            onPressed: () => ContactsService.deleteContact(_contact),
+          ),
+          IconButton(
+            icon: Icon(Icons.update),
+            onPressed: () => Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) => UpdateContactsPage(
+                  contact: _contact,
+                ),
+              ),
+            ),
+          ),
+          IconButton(
+              icon: Icon(Icons.edit),
+              onPressed: () => _openExistingContactOnDevice(context)),
+        ],
+      ),
+      body: SafeArea(
+        child: ListView(
+          children: <Widget>[
+            ListTile(
+              title: Text("Name"),
+              trailing: Text(_contact.givenName ?? ""),
+            ),
+            ListTile(
+              title: Text("Middle name"),
+              trailing: Text(_contact.middleName ?? ""),
+            ),
+            ListTile(
+              title: Text("Family name"),
+              trailing: Text(_contact.familyName ?? ""),
+            ),
+            ListTile(
+              title: Text("Prefix"),
+              trailing: Text(_contact.prefix ?? ""),
+            ),
+            ListTile(
+              title: Text("Suffix"),
+              trailing: Text(_contact.suffix ?? ""),
+            ),
+            ListTile(
+              title: Text("Birthday"),
+              trailing: Text(_contact.birthday != null
+                  ? DateFormat('dd-MM-yyyy').format(_contact.birthday)
+                  : ""),
+            ),
+            ListTile(
+              title: Text("Company"),
+              trailing: Text(_contact.company ?? ""),
+            ),
+            ListTile(
+              title: Text("Job"),
+              trailing: Text(_contact.jobTitle ?? ""),
+            ),
+            ListTile(
+              title: Text("Account Type"),
+              trailing: Text((_contact.androidAccountType != null)
+                  ? _contact.androidAccountType.toString()
+                  : ""),
+            ),
+            AddressesTile(_contact.postalAddresses),
+            ItemsTile("Phones", _contact.phones),
+            ItemsTile("Emails", _contact.emails)
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class AddressesTile extends StatelessWidget {
+  AddressesTile(this._addresses);
+
+  final Iterable<PostalAddress> _addresses;
+
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        ListTile(title: Text("Addresses")),
+        Column(
+          children: _addresses
+              .map((a) => Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: Column(
+                      children: <Widget>[
+                        ListTile(
+                          title: Text("Street"),
+                          trailing: Text(a.street ?? ""),
+                        ),
+                        ListTile(
+                          title: Text("Postcode"),
+                          trailing: Text(a.postcode ?? ""),
+                        ),
+                        ListTile(
+                          title: Text("City"),
+                          trailing: Text(a.city ?? ""),
+                        ),
+                        ListTile(
+                          title: Text("Region"),
+                          trailing: Text(a.region ?? ""),
+                        ),
+                        ListTile(
+                          title: Text("Country"),
+                          trailing: Text(a.country ?? ""),
+                        ),
+                      ],
+                    ),
+                  ))
+              .toList(),
+        ),
+      ],
+    );
+  }
+}
+
+class ItemsTile extends StatelessWidget {
+  ItemsTile(this._title, this._items);
+
+  final Iterable<Item> _items;
+  final String _title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        ListTile(title: Text(_title)),
+        Column(
+          children: _items
+              .map(
+                (i) => Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: ListTile(
+                    title: Text(i.label ?? ""),
+                    trailing: Text(i.value ?? ""),
+                  ),
+                ),
+              )
+              .toList(),
+        ),
+      ],
+    );
+  }
+}
+
+class AddContactPage extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _AddContactPageState();
+}
+
+class _AddContactPageState extends State<AddContactPage> {
+  Contact contact = Contact();
+  PostalAddress address = PostalAddress(label: "Home");
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("Add a contact"),
+        actions: <Widget>[
+          FlatButton(
+            onPressed: () {
+              _formKey.currentState.save();
+              contact.postalAddresses = [address];
+              ContactsService.addContact(contact);
+              Navigator.of(context).pop();
+            },
+            child: Icon(Icons.save, color: Colors.white),
+          )
+        ],
+      ),
+      body: Container(
+        padding: EdgeInsets.all(12.0),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: <Widget>[
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'First name'),
+                onSaved: (v) => contact.givenName = v,
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'Middle name'),
+                onSaved: (v) => contact.middleName = v,
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'Last name'),
+                onSaved: (v) => contact.familyName = v,
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'Prefix'),
+                onSaved: (v) => contact.prefix = v,
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'Suffix'),
+                onSaved: (v) => contact.suffix = v,
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'Phone'),
+                onSaved: (v) =>
+                    contact.phones = [Item(label: "mobile", value: v)],
+                keyboardType: TextInputType.phone,
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'E-mail'),
+                onSaved: (v) =>
+                    contact.emails = [Item(label: "work", value: v)],
+                keyboardType: TextInputType.emailAddress,
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'Company'),
+                onSaved: (v) => contact.company = v,
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'Job'),
+                onSaved: (v) => contact.jobTitle = v,
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'Street'),
+                onSaved: (v) => address.street = v,
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'City'),
+                onSaved: (v) => address.city = v,
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'Region'),
+                onSaved: (v) => address.region = v,
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'Postal code'),
+                onSaved: (v) => address.postcode = v,
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'Country'),
+                onSaved: (v) => address.country = v,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class UpdateContactsPage extends StatefulWidget {
+  UpdateContactsPage({@required this.contact});
+
+  final Contact contact;
+
+  @override
+  _UpdateContactsPageState createState() => _UpdateContactsPageState();
+}
+
+class _UpdateContactsPageState extends State<UpdateContactsPage> {
+  Contact contact;
+  PostalAddress address = PostalAddress(label: "Home");
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+
+  @override
+  void initState() {
+    super.initState();
+    contact = widget.contact;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("Update Contact"),
+        actions: <Widget>[
+          IconButton(
+            icon: Icon(
+              Icons.save,
+              color: Colors.white,
+            ),
+            onPressed: () async {
+              _formKey.currentState.save();
+              contact.postalAddresses = [address];
+              await ContactsService.updateContact(contact);
+              Navigator.of(context).pushReplacement(
+                  MaterialPageRoute(builder: (context) => ContactListPage()));
+            },
+          ),
+        ],
+      ),
+      body: Container(
+        padding: EdgeInsets.all(12.0),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: <Widget>[
+              TextFormField(
+                initialValue: contact.givenName ?? "",
+                decoration: const InputDecoration(labelText: 'First name'),
+                onSaved: (v) => contact.givenName = v,
+              ),
+              TextFormField(
+                initialValue: contact.middleName ?? "",
+                decoration: const InputDecoration(labelText: 'Middle name'),
+                onSaved: (v) => contact.middleName = v,
+              ),
+              TextFormField(
+                initialValue: contact.familyName ?? "",
+                decoration: const InputDecoration(labelText: 'Last name'),
+                onSaved: (v) => contact.familyName = v,
+              ),
+              TextFormField(
+                initialValue: contact.prefix ?? "",
+                decoration: const InputDecoration(labelText: 'Prefix'),
+                onSaved: (v) => contact.prefix = v,
+              ),
+              TextFormField(
+                initialValue: contact.suffix ?? "",
+                decoration: const InputDecoration(labelText: 'Suffix'),
+                onSaved: (v) => contact.suffix = v,
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'Phone'),
+                onSaved: (v) =>
+                    contact.phones = [Item(label: "mobile", value: v)],
+                keyboardType: TextInputType.phone,
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'E-mail'),
+                onSaved: (v) =>
+                    contact.emails = [Item(label: "work", value: v)],
+                keyboardType: TextInputType.emailAddress,
+              ),
+              TextFormField(
+                initialValue: contact.company ?? "",
+                decoration: const InputDecoration(labelText: 'Company'),
+                onSaved: (v) => contact.company = v,
+              ),
+              TextFormField(
+                initialValue: contact.jobTitle ?? "",
+                decoration: const InputDecoration(labelText: 'Job'),
+                onSaved: (v) => contact.jobTitle = v,
+              ),
+              TextFormField(
+                initialValue: address.street ?? "",
+                decoration: const InputDecoration(labelText: 'Street'),
+                onSaved: (v) => address.street = v,
+              ),
+              TextFormField(
+                initialValue: address.city ?? "",
+                decoration: const InputDecoration(labelText: 'City'),
+                onSaved: (v) => address.city = v,
+              ),
+              TextFormField(
+                initialValue: address.region ?? "",
+                decoration: const InputDecoration(labelText: 'Region'),
+                onSaved: (v) => address.region = v,
+              ),
+              TextFormField(
+                initialValue: address.postcode ?? "",
+                decoration: const InputDecoration(labelText: 'Postal code'),
+                onSaved: (v) => address.postcode = v,
+              ),
+              TextFormField(
+                initialValue: address.country ?? "",
+                decoration: const InputDecoration(labelText: 'Country'),
+                onSaved: (v) => address.country = v,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/contacts_picker_page.dart
+++ b/example/lib/contacts_picker_page.dart
@@ -1,0 +1,48 @@
+import 'package:contacts_service_example/main.dart';
+import 'package:flutter/material.dart';
+
+import 'package:contacts_service/contacts_service.dart';
+
+class ContactPickerPage extends StatefulWidget {
+  @override
+  _ContactPickerPageState createState() => _ContactPickerPageState();
+}
+
+class _ContactPickerPageState extends State<ContactPickerPage> {
+  Contact _contact;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  Future<void> _pickContact() async {
+    try {
+      final Contact contact = await ContactsService.openDeviceContactPicker(
+          iOSLocalizedLabels: iOSLocalizedLabels);
+      setState(() {
+        _contact = contact;
+      });
+    } catch (e) {
+      print(e.toString());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Contacts Picker Example')),
+      body: SafeArea(
+          child: Column(
+        children: <Widget>[
+          RaisedButton(
+            child: const Text('Pick a contact'),
+            onPressed: _pickContact,
+          ),
+          if (_contact != null)
+            Text('Contact selected: ${_contact.displayName}'),
+        ],
+      )),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
-import 'package:contacts_service/contacts_service.dart';
-import 'package:intl/intl.dart';
 import 'package:permission_handler/permission_handler.dart';
+
+import 'package:contacts_service_example/contacts_list_page.dart';
+import 'package:contacts_service_example/contacts_picker_page.dart';
 
 void main() => runApp(ContactsExampleApp());
 
@@ -15,61 +15,33 @@ class ContactsExampleApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: ContactListPage(),
+      home: HomePage(),
       routes: <String, WidgetBuilder>{
-        '/add': (BuildContext context) => AddContactPage()
+        '/add': (BuildContext context) => AddContactPage(),
+        '/contactsList': (BuildContext context) => ContactListPage(),
+        '/nativeContactPicker': (BuildContext context) => ContactPickerPage(),
       },
     );
   }
 }
 
-class ContactListPage extends StatefulWidget {
+class HomePage extends StatefulWidget {
   @override
-  _ContactListPageState createState() => _ContactListPageState();
+  _HomePageState createState() => _HomePageState();
 }
 
-class _ContactListPageState extends State<ContactListPage> {
-  List<Contact> _contacts;
-
+class _HomePageState extends State<HomePage> {
   @override
-  initState() {
+  void initState() {
     super.initState();
-    refreshContacts();
+    _askPermissions();
   }
 
-  refreshContacts() async {
+  Future<void> _askPermissions() async {
     PermissionStatus permissionStatus = await _getContactPermission();
-    if (permissionStatus == PermissionStatus.granted) {
-      // Load without thumbnails initially.
-      var contacts = (await ContactsService.getContacts(
-              withThumbnails: false, iOSLocalizedLabels: iOSLocalizedLabels))
-          .toList();
-//      var contacts = (await ContactsService.getContactsForPhone("8554964652"))
-//          .toList();
-      setState(() {
-        _contacts = contacts;
-      });
-
-      // Lazy load thumbnails after rendering initial contacts.
-      for (final contact in contacts) {
-        ContactsService.getAvatar(contact).then((avatar) {
-          if (avatar == null) return; // Don't redraw if no change.
-          setState(() => contact.avatar = avatar);
-        });
-      }
-    } else {
+    if (permissionStatus != PermissionStatus.granted) {
       _handleInvalidPermissions(permissionStatus);
     }
-  }
-
-  updateContact() async {
-    Contact ninja = _contacts
-        .toList()
-        .firstWhere((contact) => contact.familyName.startsWith("Ninja"));
-    ninja.avatar = null;
-    await ContactsService.updateContact(ninja);
-
-    refreshContacts();
   }
 
   Future<PermissionStatus> _getContactPermission() async {
@@ -89,500 +61,36 @@ class _ContactListPageState extends State<ContactListPage> {
 
   void _handleInvalidPermissions(PermissionStatus permissionStatus) {
     if (permissionStatus == PermissionStatus.denied) {
-      throw new PlatformException(
+      throw PlatformException(
           code: "PERMISSION_DENIED",
           message: "Access to location data denied",
           details: null);
     } else if (permissionStatus == PermissionStatus.disabled) {
-      throw new PlatformException(
+      throw PlatformException(
           code: "PERMISSION_DISABLED",
           message: "Location data is not available on device",
           details: null);
     }
   }
 
-  _openContactForm() async {
-    try {
-      var contact = await ContactsService.openContactForm(
-          iOSLocalizedLabels: iOSLocalizedLabels);
-      refreshContacts();
-    } on FormOperationException catch (e) {
-      switch (e.errorCode) {
-        case FormOperationErrorCode.FORM_OPERATION_CANCELED:
-        case FormOperationErrorCode.FORM_COULD_NOT_BE_OPEN:
-        case FormOperationErrorCode.FORM_OPERATION_UNKNOWN_ERROR:
-        default:
-          print(e.errorCode);
-      }
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          'Contacts Plugin Example',
-        ),
-        actions: <Widget>[
-          IconButton(
-            icon: Icon(Icons.create),
-            onPressed: _openContactForm,
-          )
-        ],
-      ),
-      floatingActionButton: FloatingActionButton(
-        child: Icon(Icons.add),
-        onPressed: () {
-          Navigator.of(context).pushNamed("/add").then((_) {
-            refreshContacts();
-          });
-        },
-      ),
+      appBar: AppBar(title: const Text('Contacts Plugin Example')),
       body: SafeArea(
-        child: _contacts != null
-            ? ListView.builder(
-                itemCount: _contacts?.length ?? 0,
-                itemBuilder: (BuildContext context, int index) {
-                  Contact c = _contacts?.elementAt(index);
-                  return ListTile(
-                    onTap: () {
-                      Navigator.of(context).push(MaterialPageRoute(
-                          builder: (BuildContext context) => ContactDetailsPage(
-                                c,
-                                onContactDeviceSave:
-                                    contactOnDeviceHasBeenUpdated,
-                              )));
-                    },
-                    leading: (c.avatar != null && c.avatar.length > 0)
-                        ? CircleAvatar(backgroundImage: MemoryImage(c.avatar))
-                        : CircleAvatar(child: Text(c.initials())),
-                    title: Text(c.displayName ?? ""),
-                  );
-                },
-              )
-            : Center(
-                child: CircularProgressIndicator(),
-              ),
-      ),
-    );
-  }
-
-  void contactOnDeviceHasBeenUpdated(Contact contact) {
-    this.setState(() {
-      var id = _contacts.indexWhere((c) => c.identifier == contact.identifier);
-      _contacts[id] = contact;
-    });
-  }
-}
-
-class ContactDetailsPage extends StatelessWidget {
-  ContactDetailsPage(this._contact, {this.onContactDeviceSave});
-
-  final Contact _contact;
-  final Function(Contact) onContactDeviceSave;
-
-  _openExistingContactOnDevice(BuildContext context) async {
-    try {
-      var contact = await ContactsService.openExistingContact(_contact,
-          iOSLocalizedLabels: iOSLocalizedLabels);
-      print(contact.emails.first.label);
-      if (onContactDeviceSave != null) {
-        onContactDeviceSave(contact);
-      }
-      Navigator.of(context).pop();
-    } on FormOperationException catch (e) {
-      switch (e.errorCode) {
-        case FormOperationErrorCode.FORM_OPERATION_CANCELED:
-        case FormOperationErrorCode.FORM_COULD_NOT_BE_OPEN:
-        case FormOperationErrorCode.FORM_OPERATION_UNKNOWN_ERROR:
-        default:
-          print(e.toString());
-      }
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(_contact.displayName ?? ""),
-        actions: <Widget>[
-//          IconButton(
-//            icon: Icon(Icons.share),
-//            onPressed: () => shareVCFCard(context, contact: _contact),
-//          ),
-          IconButton(
-            icon: Icon(Icons.delete),
-            onPressed: () => ContactsService.deleteContact(_contact),
-          ),
-          IconButton(
-            icon: Icon(Icons.update),
-            onPressed: () => Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (context) => UpdateContactsPage(
-                  contact: _contact,
-                ),
-              ),
-            ),
-          ),
-          IconButton(
-              icon: Icon(Icons.edit),
-              onPressed: () => _openExistingContactOnDevice(context)),
-        ],
-      ),
-      body: SafeArea(
-        child: ListView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: <Widget>[
-            ListTile(
-              title: Text("Name"),
-              trailing: Text(_contact.givenName ?? ""),
+            RaisedButton(
+              child: const Text('Contacts list'),
+              onPressed: () => Navigator.pushNamed(context, '/contactsList'),
             ),
-            ListTile(
-              title: Text("Middle name"),
-              trailing: Text(_contact.middleName ?? ""),
+            RaisedButton(
+              child: const Text('Native Contacts picker'),
+              onPressed: () =>
+                  Navigator.pushNamed(context, '/nativeContactPicker'),
             ),
-            ListTile(
-              title: Text("Family name"),
-              trailing: Text(_contact.familyName ?? ""),
-            ),
-            ListTile(
-              title: Text("Prefix"),
-              trailing: Text(_contact.prefix ?? ""),
-            ),
-            ListTile(
-              title: Text("Suffix"),
-              trailing: Text(_contact.suffix ?? ""),
-            ),
-            ListTile(
-              title: Text("Birthday"),
-              trailing: Text(_contact.birthday != null
-                  ? DateFormat('dd-MM-yyyy').format(_contact.birthday)
-                  : ""),
-            ),
-            ListTile(
-              title: Text("Company"),
-              trailing: Text(_contact.company ?? ""),
-            ),
-            ListTile(
-              title: Text("Job"),
-              trailing: Text(_contact.jobTitle ?? ""),
-            ),
-            ListTile(
-              title: Text("Account Type"),
-              trailing: Text((_contact.androidAccountType != null)
-                  ? _contact.androidAccountType.toString()
-                  : ""),
-            ),
-            AddressesTile(_contact.postalAddresses),
-            ItemsTile("Phones", _contact.phones),
-            ItemsTile("Emails", _contact.emails)
           ],
-        ),
-      ),
-    );
-  }
-}
-
-class AddressesTile extends StatelessWidget {
-  AddressesTile(this._addresses);
-
-  final Iterable<PostalAddress> _addresses;
-
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        ListTile(title: Text("Addresses")),
-        Column(
-          children: _addresses
-              .map((a) => Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                    child: Column(
-                      children: <Widget>[
-                        ListTile(
-                          title: Text("Street"),
-                          trailing: Text(a.street ?? ""),
-                        ),
-                        ListTile(
-                          title: Text("Postcode"),
-                          trailing: Text(a.postcode ?? ""),
-                        ),
-                        ListTile(
-                          title: Text("City"),
-                          trailing: Text(a.city ?? ""),
-                        ),
-                        ListTile(
-                          title: Text("Region"),
-                          trailing: Text(a.region ?? ""),
-                        ),
-                        ListTile(
-                          title: Text("Country"),
-                          trailing: Text(a.country ?? ""),
-                        ),
-                      ],
-                    ),
-                  ))
-              .toList(),
-        ),
-      ],
-    );
-  }
-}
-
-class ItemsTile extends StatelessWidget {
-  ItemsTile(this._title, this._items);
-
-  final Iterable<Item> _items;
-  final String _title;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        ListTile(title: Text(_title)),
-        Column(
-          children: _items
-              .map(
-                (i) => Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  child: ListTile(
-                    title: Text(i.label ?? ""),
-                    trailing: Text(i.value ?? ""),
-                  ),
-                ),
-              )
-              .toList(),
-        ),
-      ],
-    );
-  }
-}
-
-class AddContactPage extends StatefulWidget {
-  @override
-  State<StatefulWidget> createState() => _AddContactPageState();
-}
-
-class _AddContactPageState extends State<AddContactPage> {
-  Contact contact = Contact();
-  PostalAddress address = PostalAddress(label: "Home");
-  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text("Add a contact"),
-        actions: <Widget>[
-          FlatButton(
-            onPressed: () {
-              _formKey.currentState.save();
-              contact.postalAddresses = [address];
-              ContactsService.addContact(contact);
-              Navigator.of(context).pop();
-            },
-            child: Icon(Icons.save, color: Colors.white),
-          )
-        ],
-      ),
-      body: Container(
-        padding: EdgeInsets.all(12.0),
-        child: Form(
-          key: _formKey,
-          child: ListView(
-            children: <Widget>[
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'First name'),
-                onSaved: (v) => contact.givenName = v,
-              ),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'Middle name'),
-                onSaved: (v) => contact.middleName = v,
-              ),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'Last name'),
-                onSaved: (v) => contact.familyName = v,
-              ),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'Prefix'),
-                onSaved: (v) => contact.prefix = v,
-              ),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'Suffix'),
-                onSaved: (v) => contact.suffix = v,
-              ),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'Phone'),
-                onSaved: (v) =>
-                    contact.phones = [Item(label: "mobile", value: v)],
-                keyboardType: TextInputType.phone,
-              ),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'E-mail'),
-                onSaved: (v) =>
-                    contact.emails = [Item(label: "work", value: v)],
-                keyboardType: TextInputType.emailAddress,
-              ),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'Company'),
-                onSaved: (v) => contact.company = v,
-              ),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'Job'),
-                onSaved: (v) => contact.jobTitle = v,
-              ),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'Street'),
-                onSaved: (v) => address.street = v,
-              ),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'City'),
-                onSaved: (v) => address.city = v,
-              ),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'Region'),
-                onSaved: (v) => address.region = v,
-              ),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'Postal code'),
-                onSaved: (v) => address.postcode = v,
-              ),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'Country'),
-                onSaved: (v) => address.country = v,
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class UpdateContactsPage extends StatefulWidget {
-  UpdateContactsPage({@required this.contact});
-
-  final Contact contact;
-
-  @override
-  _UpdateContactsPageState createState() => _UpdateContactsPageState();
-}
-
-class _UpdateContactsPageState extends State<UpdateContactsPage> {
-  Contact contact;
-  PostalAddress address = PostalAddress(label: "Home");
-  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
-
-  @override
-  void initState() {
-    super.initState();
-    contact = widget.contact;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text("Update Contact"),
-        actions: <Widget>[
-          IconButton(
-            icon: Icon(
-              Icons.save,
-              color: Colors.white,
-            ),
-            onPressed: () async {
-              _formKey.currentState.save();
-              contact.postalAddresses = [address];
-              await ContactsService.updateContact(contact).then((_) {
-                Navigator.of(context).pushReplacement(
-                    MaterialPageRoute(builder: (context) => ContactListPage()));
-              });
-            },
-          ),
-        ],
-      ),
-      body: Container(
-        padding: EdgeInsets.all(12.0),
-        child: Form(
-          key: _formKey,
-          child: ListView(
-            children: <Widget>[
-              TextFormField(
-                initialValue: contact.givenName ?? "",
-                decoration: const InputDecoration(labelText: 'First name'),
-                onSaved: (v) => contact.givenName = v,
-              ),
-              TextFormField(
-                initialValue: contact.middleName ?? "",
-                decoration: const InputDecoration(labelText: 'Middle name'),
-                onSaved: (v) => contact.middleName = v,
-              ),
-              TextFormField(
-                initialValue: contact.familyName ?? "",
-                decoration: const InputDecoration(labelText: 'Last name'),
-                onSaved: (v) => contact.familyName = v,
-              ),
-              TextFormField(
-                initialValue: contact.prefix ?? "",
-                decoration: const InputDecoration(labelText: 'Prefix'),
-                onSaved: (v) => contact.prefix = v,
-              ),
-              TextFormField(
-                initialValue: contact.suffix ?? "",
-                decoration: const InputDecoration(labelText: 'Suffix'),
-                onSaved: (v) => contact.suffix = v,
-              ),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'Phone'),
-                onSaved: (v) =>
-                    contact.phones = [Item(label: "mobile", value: v)],
-                keyboardType: TextInputType.phone,
-              ),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'E-mail'),
-                onSaved: (v) =>
-                    contact.emails = [Item(label: "work", value: v)],
-                keyboardType: TextInputType.emailAddress,
-              ),
-              TextFormField(
-                initialValue: contact.company ?? "",
-                decoration: const InputDecoration(labelText: 'Company'),
-                onSaved: (v) => contact.company = v,
-              ),
-              TextFormField(
-                initialValue: contact.jobTitle ?? "",
-                decoration: const InputDecoration(labelText: 'Job'),
-                onSaved: (v) => contact.jobTitle = v,
-              ),
-              TextFormField(
-                initialValue: address.street ?? "",
-                decoration: const InputDecoration(labelText: 'Street'),
-                onSaved: (v) => address.street = v,
-              ),
-              TextFormField(
-                initialValue: address.city ?? "",
-                decoration: const InputDecoration(labelText: 'City'),
-                onSaved: (v) => address.city = v,
-              ),
-              TextFormField(
-                initialValue: address.region ?? "",
-                decoration: const InputDecoration(labelText: 'Region'),
-                onSaved: (v) => address.region = v,
-              ),
-              TextFormField(
-                initialValue: address.postcode ?? "",
-                decoration: const InputDecoration(labelText: 'Postal code'),
-                onSaved: (v) => address.postcode = v,
-              ),
-              TextFormField(
-                initialValue: address.country ?? "",
-                decoration: const InputDecoration(labelText: 'Country'),
-                onSaved: (v) => address.country = v,
-              ),
-            ],
-          ),
         ),
       ),
     );

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -7,7 +7,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:contacts_service_example/main.dart';
+import 'package:contacts_service_example/contacts_list_page.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {

--- a/lib/contacts_service.dart
+++ b/lib/contacts_service.dart
@@ -105,6 +105,23 @@ class ContactsService {
    return _handleFormOperation(result);
   }
 
+  // Displays the device/native contact picker dialog and returns the contact selected by the user
+  static Future<Contact> openDeviceContactPicker({bool iOSLocalizedLabels = true}) async {
+    dynamic result = await _channel.invokeMethod('openDeviceContactPicker',<String,dynamic>{
+      'iOSLocalizedLabels': iOSLocalizedLabels,
+    });
+    // result contains either :
+    // - an Iterable of contacts containing 0 or 1 contact
+    // - a FormOperationErrorCode value
+    if (result is Iterable) {
+      if (result.isEmpty) {
+        return null;
+      }
+      result = result.first;
+    }
+    return _handleFormOperation(result);
+  }
+
   static Contact _handleFormOperation(dynamic result) {
     if(result is int) {
       switch (result) {


### PR DESCRIPTION
This PR adds a new functionality : it opens the native device contact picker corresponding on each native platform (Android or iOS). The user can then search and select a specific contact.

It uses:
Android: Intent.ACTION_PICK
iOS: CNContactPickerViewController