### PR TITLE
Fix getting rootViewController

### DIFF
--- a/ios/Classes/SwiftContactsServicePlugin.swift
+++ b/ios/Classes/SwiftContactsServicePlugin.swift
@@ -14,12 +14,11 @@ public class SwiftContactsServicePlugin: NSObject, FlutterPlugin, CNContactViewC
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "github.com/clovisnicolas/flutter_contacts", binaryMessenger: registrar.messenger())
         if let rootViewController = SwiftContactsServicePlugin.getRootViewController() {
-            print("Contact Service navite iOS: Find root view controller");
             let instance = SwiftContactsServicePlugin(rootViewController)
             registrar.addMethodCallDelegate(instance, channel: channel)
             instance.preLoadContactView()
         } else {
-            print("Contact Service navite iOS: Can NOT find root view controller");
+            print("Error contacts service native iOS: Can NOT find root view controller");
         }
     }
     

--- a/ios/Classes/SwiftContactsServicePlugin.swift
+++ b/ios/Classes/SwiftContactsServicePlugin.swift
@@ -13,10 +13,27 @@ public class SwiftContactsServicePlugin: NSObject, FlutterPlugin, CNContactViewC
     
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "github.com/clovisnicolas/flutter_contacts", binaryMessenger: registrar.messenger())
-        let rootViewController = UIApplication.shared.delegate!.window!!.rootViewController!;
-        let instance = SwiftContactsServicePlugin(rootViewController)
-        registrar.addMethodCallDelegate(instance, channel: channel)
-        instance.preLoadContactView()
+        if let rootViewController = SwiftContactsServicePlugin.getRootViewController() {
+            print("Contact Service navite iOS: Find root view controller");
+            let instance = SwiftContactsServicePlugin(rootViewController)
+            registrar.addMethodCallDelegate(instance, channel: channel)
+            instance.preLoadContactView()
+        } else {
+            print("Contact Service navite iOS: Can NOT find root view controller");
+        }
+    }
+    
+    static func getRootViewController() -> UIViewController? {
+        var window: UIWindow?
+        if #available(iOS 13.0, *) {
+            let windowScenes: UIWindowScene? = UIApplication.shared.connectedScenes
+                .first(where: { $0 is UIWindowScene }) as? UIWindowScene;
+            window = windowScenes?.windows.first(where: { $0.isKeyWindow }) ?? windowScenes?.windows.first
+        } else {
+            window = UIApplication.shared.delegate?.window as? UIWindow;
+        }
+        let rootViewController = window?.rootViewController;
+        return rootViewController;
     }
 
     init(_ rootViewController: UIViewController) {


### PR DESCRIPTION
I created flutter module to use it as library in native app. I used your  plugin to get contacts. But I had runtime error in native app when tried to register plugins 
`GeneratedPluginRegistrant.register(with: flutterEngine);`

```
SwiftContactsServicePlugin.swift:16: Fatal error: Unexpectedly found nil while unwrapping an Optional value
Line 16 in SwiftContactsServicePlugin.swift: 
let rootViewController = UIApplication.shared.delegate!.window!!.rootViewController!;
```
I did it according [Flutter Docs](https://docs.flutter.dev/development/add-to-app/ios/add-flutter-screen?tab=engine-swift-tab) to interaction with my module. I tried add window variable to my AppDelegate but it didn't help.
iOS 13+ has new methods and classes for getting window. With my changes I got the rootViewController but I think the runtime error is bad practice anyway so just add an error message to log when rootViewController still nil.