### PR TITLE
adding (if) avoid app crashed if intent is null

### DIFF
--- a/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
+++ b/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
@@ -286,6 +286,9 @@ public class ContactsServicePlugin implements MethodCallHandler, FlutterPlugin, 
           finishWithResult(FORM_OPERATION_CANCELED);
           return true;
         }
+        if(intent == null){
+          return false;
+        }
         Uri contactUri = intent.getData();
           if (intent != null){
         Cursor cursor = contentResolver.query(contactUri, null, null, null, null);


### PR DESCRIPTION
by adding if statement we avoid App crash when the user return without select any contact because Intent is null.