### PR TITLE
Namespace declaration for Gradle >= 8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace "flutter.plugins.contactsservice.contactsservice"
     compileSdkVersion 30
 
     defaultConfig {


### PR DESCRIPTION
#343 Add namespace for contacts service plugin in build.gradle  this is for those that will use targetsdkverion 35 and compilesdkversion 35 in Android